### PR TITLE
fixed bug with function get_slides()

### DIFF
--- a/includes/class.total-slide-group.php
+++ b/includes/class.total-slide-group.php
@@ -215,6 +215,7 @@ class Total_Slide_Group {
 			'orderby'            => 'meta_value_num',
 			'order'              => 'ASC',
 			'meta_key'           => 'total_slider_meta_sequence',
+			'posts_per_page'           => -1,
 		);
 
 		$raw = new WP_Query( $args );


### PR DESCRIPTION
Hi,
Without this argument, the slider group will take the post per page setting of wordpress by default.
is it possible to fix it in a next release. thanks
